### PR TITLE
fix github issue #125 - grave gold not buried

### DIFF
--- a/doc/fixes36.2
+++ b/doc/fixes36.2
@@ -85,6 +85,8 @@ making a wide-open special level with FLAGS:inaccessibles could trigger a
 	"floodfill stack overrun" panic (no 3.6.x levels were affected)
 wallifying a special level might go out of map bounds (not with 3.6.x levels)
 	and corrupt other level data
+if a random grave produced during level creation included some gold, that gold
+	was left on the ground instead of being buried with other treasure
 
 
 Fixes to Post-3.6.1 Problems that Were Exposed Via git Repository

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -1626,12 +1626,23 @@ struct mkroom *croom;
             return;
     } while (occupied(m.x, m.y) || bydoor(m.x, m.y));
 
-    /* Put a grave at m.x, m.y */
+    /* Put a grave at <m.x,m.y> */
     make_grave(m.x, m.y, dobell ? "Saved by the bell!" : (char *) 0);
 
     /* Possibly fill it with objects */
-    if (!rn2(3))
-        (void) mkgold(0L, m.x, m.y);
+    if (!rn2(3)) {
+        /* this used to use mkgold(), which puts a stack of gold on
+           the ground (or merges it with an existing one there if
+           present), and didn't bother burying it; now we create a
+           loose, easily buriable, stack but we make no attempt to
+           replicate mkgold()'s level-based formula for the amount */
+        struct obj *gold = mksobj(GOLD_PIECE, TRUE, FALSE);
+
+        gold->quan = (long) (rnd(20) + level_difficulty() * rnd(5));
+        gold->owt = weight(gold);
+        gold->ox = m.x, gold->oy = m.y;
+        add_to_buried(gold);
+    }
     for (tryct = rn2(5); tryct; tryct--) {
         otmp = mkobj(RANDOM_CLASS, TRUE);
         if (!otmp)


### PR DESCRIPTION
Fixes #125

When a random grave included some gold among whatever treasure was
generated, that gold was left on top of the grave instead of being
buried inside it like other treasure.

I'm sure this was intentional but only because mkgold() puts the
gold on the ground and merges it with other gold if there is already
some present.  Keeping an existing stack of gold distinct from the
new one in order to bury the latter is feasible but clumsy.  Just
make a new gold object directly, bypassing mkgold(), and bury that.